### PR TITLE
Fix: Remove "Learn More" button

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -47,17 +47,9 @@ const Index = () => {
             <Button 
               size="lg" 
               onClick={() => navigate('/signup')}
-              className="mr-4 shadow-soft hover:shadow-medium transition-all duration-300"
+              className="shadow-soft hover:shadow-medium transition-all duration-300"
             >
               Start Your Journey
-            </Button>
-            
-            <Button 
-              variant="outline" 
-              size="lg"
-              onClick={() => navigate('/login')}
-            >
-              Learn More
             </Button>
           </div>
         </div>


### PR DESCRIPTION
The "Learn More" button was still visible on the landing page. This commit removes it.