### PR TITLE
feat: split client_profiles.user_name into first_name + last_name

### DIFF
--- a/supabase/migrations/20260417000000_client_profiles_split_name.sql
+++ b/supabase/migrations/20260417000000_client_profiles_split_name.sql
@@ -1,0 +1,16 @@
+-- Add first_name / last_name to client_profiles, backfill from existing user_name.
+-- user_name is kept (writable) for backwards compatibility with any existing
+-- consumers (ff-admin, talentflow). Once all consumers read first/last directly,
+-- a follow-up migration can drop or generate user_name.
+
+ALTER TABLE public.client_profiles
+  ADD COLUMN first_name TEXT,
+  ADD COLUMN last_name  TEXT;
+
+-- Backfill: take first whitespace-delimited token as first_name, the rest as last_name.
+-- NULLIF(..., '') ensures single-name rows get NULL last_name rather than empty string.
+UPDATE public.client_profiles
+SET
+  first_name = NULLIF(split_part(trim(user_name), ' ', 1), ''),
+  last_name  = NULLIF(regexp_replace(trim(user_name), '^\S+\s*', ''), '')
+WHERE user_name IS NOT NULL;


### PR DESCRIPTION
## Summary
- Adds `first_name` and `last_name` columns to `client_profiles`
- Backfills both columns from existing `user_name` (first whitespace token → `first_name`, remainder → `last_name`)
- Keeps `user_name` writable so existing consumers stay unaffected; ff-client-portal will write to all three on save going forward

## Why
The ff-client-portal profile + onboarding forms now collect First Name and Last Name as separate inputs (per Daniel's `feat/profile-msa-updates`). Storing them as a single `user_name` string is lossy (e.g. "Mary Anne van der Berg" → first="Mary", last="Anne van der Berg") and forces parsing on every read. Splitting them at the schema level is the right model.

## Companion PR
Frontend changes consuming these columns: Fractional-First/ff-client-portal#2

## Test plan
- [x] Migration applies cleanly to remote (Adam confirmed pushed)
- [ ] Existing rows have `first_name` / `last_name` populated correctly
- [ ] `user_name` is unchanged on existing rows (no regression for current readers)
- [ ] ff-client-portal smoke test: profile form pre-fills First/Last from columns; save round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)