### PR TITLE
feat: return anon_slug and ispublished from get_profiles_by_ids

### DIFF
--- a/supabase/migrations/20260420000000_get_profiles_by_ids_add_published_anon.sql
+++ b/supabase/migrations/20260420000000_get_profiles_by_ids_add_published_anon.sql
@@ -1,0 +1,39 @@
+-- Adds `anon_slug` and `ispublished` to get_profiles_by_ids return.
+-- /search-candidates needs both to construct named URLs (slug if published, preview otherwise)
+-- and anonymous URLs alongside the named ones for every profile.
+
+DROP FUNCTION IF EXISTS public.get_profiles_by_ids(uuid[]);
+
+CREATE OR REPLACE FUNCTION public.get_profiles_by_ids(p_ids uuid[])
+RETURNS TABLE(
+  id uuid,
+  profile_slug text,
+  anon_slug text,
+  ispublished boolean,
+  first_name text,
+  last_name text,
+  email text,
+  linkedinurl text,
+  profile_type text,
+  profile_data jsonb
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.profile_slug,
+    p.anon_slug,
+    p.ispublished,
+    p.first_name,
+    p.last_name,
+    p.email,
+    p.linkedinurl,
+    p.profile_type::text,
+    p.profile_data
+  FROM profiles p
+  WHERE p.id = ANY(p_ids);
+END;
+$function$;


### PR DESCRIPTION
## Summary

- Adds `anon_slug` and `ispublished` to the `get_profiles_by_ids` RPC return shape.
- Enables `/search-candidates` (in `fractional-command`) to construct both a named URL and an anonymous URL for every result.
- The named URL falls back to the preview route (`/profile/preview/{id}` or `/guest-profile/preview/{id}`) when `ispublished` is false or no `profile_slug` exists.

## Why

Reza reported that `/search-candidates` was returning anonymous URLs that 404'd. The actual behavior is more nuanced — for the 149 of 381 authenticated profiles that have a slug but `ispublished = false`, the slug-based URL 404s. This RPC change gives the slash command the data it needs to choose between slug URL and preview URL per profile, and to surface both anon + named for every result rather than picking one.

The `fractional-command` repo has a sibling change to its `.claude/commands/search-candidates.md` that consumes the new fields — that change is local-only (no PR needed) and takes effect once the migration is applied.

## Test plan
- [ ] Apply migration to the target database
- [ ] Verify RPC returns the two new columns: \`select * from get_profiles_by_ids(array['<some-uuid>']::uuid[])\`
- [ ] Confirm no other callers break — grep across talentflow + public-profiles confirms no other usage of this RPC
- [ ] After deployment, run /search-candidates and verify the result table has both Named and Anon columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)