### PR TITLE
fix: agreement page crash when DB fields are null

### DIFF
--- a/src/pages/dashboard/Agreement.tsx
+++ b/src/pages/dashboard/Agreement.tsx
@@ -64,13 +64,15 @@ const Agreement = () => {
   useEffect(() => {
     if (!acceptanceData) return
     setPersonalDetails({
-      fullLegalName: acceptanceData.fullLegalName,
+      fullLegalName: acceptanceData.fullLegalName ?? "",
       identificationNumber: "",
-      residentialAddress: acceptanceData.residentialAddress,
+      residentialAddress: acceptanceData.residentialAddress ?? {
+        addressLine1: "", addressLine2: "", city: "", stateProvince: "", postalCode: "", country: "",
+      },
     })
-    setContactEmail(acceptanceData.contactEmail)
-    setMobileCountryCode(acceptanceData.mobileCountryCode)
-    setMobileNumber(acceptanceData.mobileNumber)
+    setContactEmail(acceptanceData.contactEmail ?? "")
+    setMobileCountryCode(acceptanceData.mobileCountryCode ?? "")
+    setMobileNumber(acceptanceData.mobileNumber ?? "")
     setContractingType(acceptanceData.contractingType)
     if (acceptanceData.contractingType === "entity") {
       setEntityName(acceptanceData.entityName ?? "")


### PR DESCRIPTION
## Summary

- `get_current_agreement_status` returns `NULL` for fields like `contact_email`, `mobile_number`, `full_legal_name`, and `residential_address` when stored that way in the DB
- The pre-fill `useEffect` in `Agreement.tsx` was setting these nulls directly into React state, overwriting the `""` defaults
- Validation helpers then called `.trim()` on `null`, throwing `TypeError: Cannot read properties of undefined (reading 'trim')`

## Fix

Added `?? ""` / `?? {...}` fallbacks in the `useEffect` that pre-fills form state from saved acceptance data. The entity fields already had these guards — the individual/contact fields did not.

## Affected file

`src/pages/dashboard/Agreement.tsx` — 4 fields now guarded: `fullLegalName`, `residentialAddress`, `contactEmail`, `mobileCountryCode`, `mobileNumber`

## Test plan

- [ ] Visit `/dashboard/agreement` as a user with a prior accepted agreement — page should load without console errors
- [ ] Verify form pre-fills correctly when all fields are present
- [ ] Verify form loads cleanly (empty state) for users who haven't accepted yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)