### PR TITLE
feat: add list_client_signatories_admin RPC migration

### DIFF
--- a/supabase/migrations/20260424000000_list_client_signatories_admin.sql
+++ b/supabase/migrations/20260424000000_list_client_signatories_admin.sql
@@ -1,0 +1,73 @@
+CREATE OR REPLACE FUNCTION public.list_client_signatories_admin()
+RETURNS TABLE (
+  organization_id uuid,
+  company_name text,
+  company_url text,
+  company_logo text,
+  signatory_user_id uuid,
+  signatory_name text,
+  signatory_email text,
+  status text,
+  signed_at timestamptz,
+  agreement_version text,
+  contracting_type text,
+  entity_name text,
+  signed_up_at timestamptz
+)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF (auth.jwt() -> 'app_metadata' ->> 'role') IS DISTINCT FROM 'admin' THEN
+    RAISE EXCEPTION 'Unauthorized: not an admin user';
+  END IF;
+
+  RETURN QUERY
+  WITH primary_user_per_org AS (
+    SELECT DISTINCT ON (cp.organization_id) cp.*
+    FROM public.client_profiles cp
+    WHERE cp.organization_id IS NOT NULL
+    ORDER BY cp.organization_id, cp.created_at DESC
+  ),
+  orphan_users AS (
+    SELECT * FROM public.client_profiles WHERE organization_id IS NULL
+  ),
+  all_rows AS (
+    SELECT * FROM primary_user_per_org
+    UNION ALL
+    SELECT * FROM orphan_users
+  )
+  SELECT
+    o.id,
+    o.metadata->>'name',
+    o.company_url,
+    o.metadata->>'logo',
+    cp.user_id,
+    COALESCE(aa.full_legal_name, cp.user_name),
+    u.email::text,
+    CASE
+      WHEN aa.id IS NULL AND cp.organization_id IS NULL THEN 'signed_up'
+      WHEN aa.id IS NULL AND cp.is_onboarded = false    THEN 'onboarding'
+      WHEN aa.id IS NULL                                THEN 'onboarded_unsigned'
+      ELSE 'signed'
+    END,
+    aa.accepted_at,
+    aa.agreement_version,
+    aa.contracting_type,
+    aa.entity_name,
+    u.created_at
+  FROM all_rows cp
+  LEFT JOIN public.organizations o ON o.id = cp.organization_id
+  LEFT JOIN auth.users u           ON u.id = cp.user_id
+  LEFT JOIN LATERAL (
+    SELECT *
+    FROM public.agreement_acceptances
+    WHERE user_id = cp.user_id
+    ORDER BY accepted_at DESC
+    LIMIT 1
+  ) aa ON TRUE
+  ORDER BY u.created_at DESC;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.list_client_signatories_admin() TO authenticated;


### PR DESCRIPTION
## Summary

Adds the migration file for the `list_client_signatories_admin` RPC, which powers the upcoming `/clients` page in ff-admin (see `features/admin-client-signatories/` in the workspace).

## Note: migration is ALREADY APPLIED to production

This migration was applied to the production Supabase instance from this branch earlier this week, but the branch was never opened as a PR or merged. As a result, main has been out of sync with production for several days, which surfaced today when a sibling feature (feat/linkedin-connections) tried to deploy and failed with "Remote migration versions not found in local migrations directory."

**Merging this PR is purely housekeeping.** No DB changes will occur on merge — deploying against production will be a no-op for this version. The function definition in this PR matches pg_get_functiondef on production exactly.

## What's in here

- talentflow/supabase/migrations/20260424000000_list_client_signatories_admin.sql — the RPC, admin-gated via app_metadata.role = 'admin', follows the same pattern as search_candidates_admin.

## Test plan

- [x] Function exists on production (verified via pg_get_functiondef)
- [x] Migration version 20260424000000 is recorded in supabase_migrations.schema_migrations on production
- [ ] After merge: rebase feat/linkedin-connections on main; redeploy succeeds and applies only the linkedin-connections migration

## Process follow-up

To prevent this in the future, we should either (a) only apply migrations after PRs merge to main, or (b) require Ralph to open the PR as part of its task flow. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)