### PR TITLE
feat: linkedin_connections table + admin RPC support

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -30,11 +30,12 @@ export type Database = {
           ip_address: string | null
           mobile_country_code: string
           mobile_number: string
-          profile_id: string
+          profile_id: string | null
           residential_address: Json
           signature_name: string
           updated_at: string
           user_agent: string | null
+          user_id: string
         }
         Insert: {
           accepted_at?: string
@@ -51,11 +52,12 @@ export type Database = {
           ip_address?: string | null
           mobile_country_code: string
           mobile_number: string
-          profile_id: string
+          profile_id?: string | null
           residential_address: Json
           signature_name: string
           updated_at?: string
           user_agent?: string | null
+          user_id: string
         }
         Update: {
           accepted_at?: string
@@ -72,11 +74,12 @@ export type Database = {
           ip_address?: string | null
           mobile_country_code?: string
           mobile_number?: string
-          profile_id?: string
+          profile_id?: string | null
           residential_address?: Json
           signature_name?: string
           updated_at?: string
           user_agent?: string | null
+          user_id?: string
         }
         Relationships: [
           {
@@ -84,6 +87,65 @@ export type Database = {
             columns: ["profile_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      client_profiles: {
+        Row: {
+          company_email: string | null
+          created_at: string | null
+          first_name: string | null
+          id: string
+          is_onboarded: boolean | null
+          last_name: string | null
+          mobile_number: string | null
+          organization_id: string | null
+          social_links: Json | null
+          updated_at: string | null
+          user_designation: string | null
+          user_id: string
+          user_location: string | null
+          user_name: string | null
+        }
+        Insert: {
+          company_email?: string | null
+          created_at?: string | null
+          first_name?: string | null
+          id?: string
+          is_onboarded?: boolean | null
+          last_name?: string | null
+          mobile_number?: string | null
+          organization_id?: string | null
+          social_links?: Json | null
+          updated_at?: string | null
+          user_designation?: string | null
+          user_id: string
+          user_location?: string | null
+          user_name?: string | null
+        }
+        Update: {
+          company_email?: string | null
+          created_at?: string | null
+          first_name?: string | null
+          id?: string
+          is_onboarded?: boolean | null
+          last_name?: string | null
+          mobile_number?: string | null
+          organization_id?: string | null
+          social_links?: Json | null
+          updated_at?: string | null
+          user_designation?: string | null
+          user_id?: string
+          user_location?: string | null
+          user_name?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "client_profiles_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
             referencedColumns: ["id"]
           },
         ]
@@ -443,6 +505,45 @@ export type Database = {
         }
         Relationships: []
       }
+      linkedin_connections: {
+        Row: {
+          company: string | null
+          connected_on: string | null
+          email: string | null
+          first_name: string | null
+          id: string
+          imported_at: string
+          last_name: string | null
+          linkedin_username: string
+          owner: string
+          position: string | null
+        }
+        Insert: {
+          company?: string | null
+          connected_on?: string | null
+          email?: string | null
+          first_name?: string | null
+          id?: string
+          imported_at?: string
+          last_name?: string | null
+          linkedin_username: string
+          owner: string
+          position?: string | null
+        }
+        Update: {
+          company?: string | null
+          connected_on?: string | null
+          email?: string | null
+          first_name?: string | null
+          id?: string
+          imported_at?: string
+          last_name?: string | null
+          linkedin_username?: string
+          owner?: string
+          position?: string | null
+        }
+        Relationships: []
+      }
       linkedin_profiles: {
         Row: {
           city: string | null
@@ -570,6 +671,30 @@ export type Database = {
             referencedColumns: ["alpha2_code"]
           },
         ]
+      }
+      organizations: {
+        Row: {
+          company_url: string | null
+          created_at: string | null
+          id: string
+          metadata: Json | null
+          updated_at: string | null
+        }
+        Insert: {
+          company_url?: string | null
+          created_at?: string | null
+          id?: string
+          metadata?: Json | null
+          updated_at?: string | null
+        }
+        Update: {
+          company_url?: string | null
+          created_at?: string | null
+          id?: string
+          metadata?: Json | null
+          updated_at?: string | null
+        }
+        Relationships: []
       }
       profile_documents: {
         Row: {
@@ -936,6 +1061,7 @@ export type Database = {
       }
       get_candidate_admin: { Args: { candidate_id: string }; Returns: Json }
       get_candidate_details: { Args: { p_name: string }; Returns: Json }
+      get_candidate_facets: { Args: never; Returns: Json }
       get_current_agreement_status: {
         Args: { p_current_version: string }
         Returns: {
@@ -960,9 +1086,11 @@ export type Database = {
       get_profiles_by_ids: {
         Args: { p_ids: string[] }
         Returns: {
+          anon_slug: string
           email: string
           first_name: string
           id: string
+          ispublished: boolean
           last_name: string
           linkedinurl: string
           profile_data: Json
@@ -1001,6 +1129,25 @@ export type Database = {
           profile_data: Json
           profile_slug: string
           profile_version: string
+        }[]
+      }
+      linkedin_username_from_url: { Args: { url: string }; Returns: string }
+      list_client_signatories_admin: {
+        Args: never
+        Returns: {
+          agreement_version: string
+          company_logo: string
+          company_name: string
+          company_url: string
+          contracting_type: string
+          entity_name: string
+          organization_id: string
+          signatory_email: string
+          signatory_name: string
+          signatory_user_id: string
+          signed_at: string
+          signed_up_at: string
+          status: string
         }[]
       }
       list_job_descriptions: {
@@ -1048,11 +1195,12 @@ export type Database = {
               ip_address: string | null
               mobile_country_code: string
               mobile_number: string
-              profile_id: string
+              profile_id: string | null
               residential_address: Json
               signature_name: string
               updated_at: string
               user_agent: string | null
+              user_id: string
             }
             SetofOptions: {
               from: "*"
@@ -1093,11 +1241,12 @@ export type Database = {
               ip_address: string | null
               mobile_country_code: string
               mobile_number: string
-              profile_id: string
+              profile_id: string | null
               residential_address: Json
               signature_name: string
               updated_at: string
               user_agent: string | null
+              user_id: string
             }
             SetofOptions: {
               from: "*"
@@ -1125,15 +1274,18 @@ export type Database = {
           }
         | {
             Args: {
+              connected_to?: string
               has_agreement?: boolean
+              location_filter?: string[]
               open_for_work?: boolean
               page_number?: number
               page_size?: number
+              role_filter?: string[]
               search_query?: string
               sort_by?: string
               sort_dir?: string
-              status_filter?: string
-              type_filter?: string
+              status_filter?: string[]
+              type_filter?: string[]
             }
             Returns: Json
           }

--- a/supabase/migrations/20260424110000_linkedin_connections.sql
+++ b/supabase/migrations/20260424110000_linkedin_connections.sql
@@ -1,0 +1,215 @@
+-- LinkedIn Connections: table, URL extraction function, updated search_candidates_admin RPC.
+
+-- (a) Table + indexes
+CREATE TABLE public.linkedin_connections (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner text NOT NULL,
+  linkedin_username text NOT NULL,
+  first_name text,
+  last_name text,
+  email text,
+  company text,
+  position text,
+  connected_on date,
+  imported_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(owner, linkedin_username)
+);
+CREATE INDEX idx_linkedin_connections_username ON public.linkedin_connections(linkedin_username);
+CREATE INDEX idx_linkedin_connections_owner ON public.linkedin_connections(owner);
+
+-- (b) URL extraction function — extracts the /in/<slug> from any LinkedIn profile URL.
+CREATE OR REPLACE FUNCTION public.linkedin_username_from_url(url text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN url IS NULL OR url = '' THEN NULL
+    WHEN url !~ '/in/' THEN NULL
+    ELSE lower(regexp_replace(
+      regexp_replace(url, '^.*/in/', ''),
+      '[/?#].*$', ''
+    ))
+  END;
+$$;
+
+-- (c) Drop current search_candidates_admin (11-param signature) and recreate with
+--     connected_to param + reza_connected output column.
+DROP FUNCTION IF EXISTS public.search_candidates_admin(
+  text, text[], text[], text[], text[], boolean, boolean, integer, integer, text, text
+);
+
+CREATE OR REPLACE FUNCTION public.search_candidates_admin(
+  search_query text DEFAULT NULL,
+  status_filter text[] DEFAULT NULL,
+  type_filter text[] DEFAULT NULL,
+  location_filter text[] DEFAULT NULL,
+  role_filter text[] DEFAULT NULL,
+  has_agreement boolean DEFAULT NULL,
+  open_for_work boolean DEFAULT NULL,
+  connected_to text DEFAULT NULL,
+  page_number integer DEFAULT 1,
+  page_size integer DEFAULT 25,
+  sort_by text DEFAULT 'created_at',
+  sort_dir text DEFAULT 'desc'
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  result json;
+  offset_val int;
+  total_count int;
+  order_clause text;
+BEGIN
+  IF (auth.jwt() -> 'app_metadata' ->> 'role') IS DISTINCT FROM 'admin' THEN
+    RAISE EXCEPTION 'Unauthorized: not an admin user';
+  END IF;
+
+  offset_val := (page_number - 1) * page_size;
+
+  -- Validate sort_dir to prevent injection
+  IF sort_dir NOT IN ('asc', 'desc') THEN
+    sort_dir := 'desc';
+  END IF;
+
+  -- Validate sort_by via whitelist and build ORDER BY expression.
+  CASE sort_by
+    WHEN 'name' THEN
+      order_clause := 'name_computed ' || sort_dir || ' NULLS LAST';
+    WHEN 'email' THEN
+      order_clause := 'email ' || sort_dir;
+    WHEN 'role' THEN
+      order_clause := 'role ' || sort_dir || ' NULLS LAST';
+    WHEN 'location' THEN
+      order_clause := 'location ' || sort_dir || ' NULLS LAST';
+    WHEN 'onboarding_status' THEN
+      order_clause := 'CASE onboarding_status
+        WHEN ''SET_PASSWORD'' THEN 1
+        WHEN ''SIGNED_UP'' THEN 2
+        WHEN ''EMAIL_CONFIRMED'' THEN 3
+        WHEN ''PROFILE_GENERATED'' THEN 4
+        WHEN ''PROFILE_CONFIRMED'' THEN 5
+        WHEN ''PREFERENCES_SET'' THEN 6
+        ELSE 99
+      END ' || sort_dir;
+    WHEN 'profile_type' THEN
+      order_clause := 'profile_type ' || sort_dir;
+    WHEN 'has_agreement' THEN
+      order_clause := 'has_agreement ' || sort_dir;
+    WHEN 'agreement_date' THEN
+      order_clause := 'agreement_date ' || sort_dir || ' NULLS LAST';
+    WHEN 'updated_at' THEN
+      order_clause := 'updated_at ' || sort_dir || ' NULLS LAST';
+    ELSE -- 'created_at' and any unrecognized value
+      order_clause := 'created_at ' || sort_dir;
+  END CASE;
+
+  -- Count matching rows
+  SELECT COUNT(*) INTO total_count
+  FROM profiles p
+  LEFT JOIN auth.users u ON u.id = p.id
+  WHERE
+    (search_query IS NULL OR (
+      COALESCE(NULLIF(p.first_name, ''), NULLIF(u.raw_user_meta_data->>'first_name', ''), SPLIT_PART(NULLIF(u.raw_user_meta_data->>'name', ''), ' ', 1)) ILIKE '%' || search_query || '%' OR
+      COALESCE(NULLIF(p.last_name, ''), NULLIF(u.raw_user_meta_data->>'last_name', ''), NULLIF(SUBSTRING(u.raw_user_meta_data->>'name' FROM POSITION(' ' IN COALESCE(u.raw_user_meta_data->>'name', '')) + 1), '')) ILIKE '%' || search_query || '%' OR
+      p.email ILIKE '%' || search_query || '%' OR
+      p.profile_data->>'role' ILIKE '%' || search_query || '%' OR
+      p.profile_data->>'summary' ILIKE '%' || search_query || '%'
+    ))
+    AND (status_filter IS NULL OR p.onboarding_status::text = ANY(status_filter))
+    AND (type_filter IS NULL OR p.profile_type::text = ANY(type_filter))
+    AND (location_filter IS NULL OR p.profile_data->>'location' = ANY(location_filter))
+    AND (role_filter IS NULL OR p.profile_data->>'role' = ANY(role_filter))
+    AND (has_agreement IS NULL OR (
+      CASE WHEN has_agreement THEN
+        EXISTS (SELECT 1 FROM agreement_acceptances aa WHERE aa.profile_id = p.id)
+      ELSE
+        NOT EXISTS (SELECT 1 FROM agreement_acceptances aa WHERE aa.profile_id = p.id)
+      END
+    ))
+    AND (open_for_work IS NULL OR EXISTS (
+      SELECT 1 FROM fractional_preferences fp WHERE fp.user_id = p.id AND fp.open_for_work = search_candidates_admin.open_for_work
+    ))
+    AND (connected_to IS NULL OR EXISTS (
+      SELECT 1 FROM public.linkedin_connections lc
+      WHERE lc.owner = connected_to
+      AND lc.linkedin_username = public.linkedin_username_from_url(p.linkedinurl)
+    ));
+
+  -- Fetch page with dynamic ORDER BY.
+  -- Positional params: $1=total_count, $2=page_number, $3=page_size,
+  -- $4=search_query, $5=status_filter, $6=type_filter, $7=location_filter,
+  -- $8=role_filter, $9=has_agreement, $10=open_for_work, $11=offset_val, $12=connected_to
+  EXECUTE format(
+    'SELECT json_build_object(
+      ''data'', COALESCE(json_agg(row_to_json(t)), ''[]''::json),
+      ''total'', $1,
+      ''page'', $2,
+      ''pageSize'', $3,
+      ''totalPages'', CEIL($1::float / $3)
+    )
+    FROM (
+      SELECT
+        p.id,
+        p.email,
+        COALESCE(NULLIF(p.first_name, ''''), NULLIF(u.raw_user_meta_data->>''first_name'', ''''), SPLIT_PART(NULLIF(u.raw_user_meta_data->>''name'', ''''), '' '', 1)) AS first_name,
+        COALESCE(NULLIF(p.last_name, ''''), NULLIF(u.raw_user_meta_data->>''last_name'', ''''), NULLIF(SUBSTRING(u.raw_user_meta_data->>''name'' FROM POSITION('' '' IN COALESCE(u.raw_user_meta_data->>''name'', '''')) + 1), '''')) AS last_name,
+        (
+          COALESCE(NULLIF(p.first_name, ''''), NULLIF(u.raw_user_meta_data->>''first_name'', ''''), SPLIT_PART(NULLIF(u.raw_user_meta_data->>''name'', ''''), '' '', 1)) || '' '' ||
+          COALESCE(NULLIF(p.last_name, ''''), NULLIF(u.raw_user_meta_data->>''last_name'', ''''), NULLIF(SUBSTRING(u.raw_user_meta_data->>''name'' FROM POSITION('' '' IN COALESCE(u.raw_user_meta_data->>''name'', '''')) + 1), ''''))
+        ) AS name_computed,
+        p.profile_type::text AS profile_type,
+        p.onboarding_status::text AS onboarding_status,
+        p.ispublished,
+        p.linkedinurl,
+        p.created_at,
+        p.updated_at,
+        p.profile_data->>''role'' AS role,
+        p.profile_data->>''location'' AS location,
+        EXISTS (SELECT 1 FROM agreement_acceptances aa WHERE aa.profile_id = p.id) AS has_agreement,
+        (SELECT aa.accepted_at FROM agreement_acceptances aa WHERE aa.profile_id = p.id ORDER BY aa.created_at DESC LIMIT 1) AS agreement_date,
+        (SELECT fp.open_for_work FROM fractional_preferences fp WHERE fp.user_id = p.id) AS fractional_open,
+        (SELECT ftp.open_for_work FROM full_time_preferences ftp WHERE ftp.user_id = p.id) AS fulltime_open,
+        p.profile_slug,
+        p.anon_slug,
+        EXISTS (SELECT 1 FROM public.linkedin_connections lc WHERE lc.owner = ''reza'' AND lc.linkedin_username = public.linkedin_username_from_url(p.linkedinurl)) AS reza_connected
+      FROM profiles p
+      LEFT JOIN auth.users u ON u.id = p.id
+      WHERE
+        ($4 IS NULL OR (
+          COALESCE(NULLIF(p.first_name, ''''), NULLIF(u.raw_user_meta_data->>''first_name'', ''''), SPLIT_PART(NULLIF(u.raw_user_meta_data->>''name'', ''''), '' '', 1)) ILIKE ''%%'' || $4 || ''%%'' OR
+          COALESCE(NULLIF(p.last_name, ''''), NULLIF(u.raw_user_meta_data->>''last_name'', ''''), NULLIF(SUBSTRING(u.raw_user_meta_data->>''name'' FROM POSITION('' '' IN COALESCE(u.raw_user_meta_data->>''name'', '''')) + 1), '''')) ILIKE ''%%'' || $4 || ''%%'' OR
+          p.email ILIKE ''%%'' || $4 || ''%%'' OR
+          p.profile_data->>''role'' ILIKE ''%%'' || $4 || ''%%'' OR
+          p.profile_data->>''summary'' ILIKE ''%%'' || $4 || ''%%''
+        ))
+        AND ($5 IS NULL OR p.onboarding_status::text = ANY($5))
+        AND ($6 IS NULL OR p.profile_type::text = ANY($6))
+        AND ($7 IS NULL OR p.profile_data->>''location'' = ANY($7))
+        AND ($8 IS NULL OR p.profile_data->>''role'' = ANY($8))
+        AND ($9 IS NULL OR (
+          CASE WHEN $9 THEN
+            EXISTS (SELECT 1 FROM agreement_acceptances aa WHERE aa.profile_id = p.id)
+          ELSE
+            NOT EXISTS (SELECT 1 FROM agreement_acceptances aa WHERE aa.profile_id = p.id)
+          END
+        ))
+        AND ($10 IS NULL OR EXISTS (
+          SELECT 1 FROM fractional_preferences fp WHERE fp.user_id = p.id AND fp.open_for_work = $10
+        ))
+        AND ($12 IS NULL OR EXISTS (
+          SELECT 1 FROM public.linkedin_connections lc WHERE lc.owner = $12 AND lc.linkedin_username = public.linkedin_username_from_url(p.linkedinurl)
+        ))
+      ORDER BY %s
+      LIMIT $3 OFFSET $11
+    ) t',
+    order_clause
+  )
+  INTO result
+  USING total_count, page_number, page_size, search_query, status_filter, type_filter, location_filter, role_filter, has_agreement, open_for_work, offset_val, connected_to;
+
+  RETURN result;
+END;
+$function$;

--- a/supabase/migrations/20260427000000_linkedin_connections_enable_rls.sql
+++ b/supabase/migrations/20260427000000_linkedin_connections_enable_rls.sql
@@ -1,0 +1,6 @@
+-- Enable RLS on linkedin_connections to prevent Data API exposure.
+-- No policies are added: the table is only ever accessed via the service-role
+-- key (import script) and SECURITY DEFINER RPCs (search_candidates_admin),
+-- both of which bypass RLS. Anon and authenticated roles get default-deny.
+
+ALTER TABLE public.linkedin_connections ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

- New `linkedin_connections` table keyed by `(owner, linkedin_username)` for storing Reza's (and future owners') LinkedIn connections.
- New `linkedin_username_from_url(text)` function to extract canonical usernames from LinkedIn URLs (used by both this RPC and the workspace import script).
- Updated `search_candidates_admin` RPC: adds `connected_to text` param and `reza_connected boolean` output column.
- RLS is enabled on the new table with no policies — service-role (import script) and SECURITY DEFINER (admin RPC) callers bypass RLS, so anon/authenticated get default-deny, preventing Data API exposure.

## Context

PRD: [features/linkedin-connections/PRD.md in ff-workspace](https://github.com/Fractional-First/ff-workspace/blob/main/features/linkedin-connections/PRD.md).

Both migrations have already been applied to production (the table exists, the RPC works). This PR brings the SQL files into main so we don't repeat the phantom-migration issue from the previous Ralph run.

## Test plan

- [ ] Existing `search_candidates_admin` calls (without `connected_to`) still return the same shape (plus the new `reza_connected` column).
- [ ] `connected_to='reza'` filter narrows to only candidates with a matching `linkedin_username`.
- [ ] Anon role cannot SELECT from `linkedin_connections` directly via the Data API.
- [ ] Service-role import script can still upsert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)