### PR TITLE
fix: resolve ambiguous column ref in list_client_signatories_admin

### DIFF
--- a/supabase/migrations/20260424000000_list_client_signatories_admin.sql
+++ b/supabase/migrations/20260424000000_list_client_signatories_admin.sql
@@ -1,0 +1,73 @@
+CREATE OR REPLACE FUNCTION public.list_client_signatories_admin()
+RETURNS TABLE (
+  organization_id uuid,
+  company_name text,
+  company_url text,
+  company_logo text,
+  signatory_user_id uuid,
+  signatory_name text,
+  signatory_email text,
+  status text,
+  signed_at timestamptz,
+  agreement_version text,
+  contracting_type text,
+  entity_name text,
+  signed_up_at timestamptz
+)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF (auth.jwt() -> 'app_metadata' ->> 'role') IS DISTINCT FROM 'admin' THEN
+    RAISE EXCEPTION 'Unauthorized: not an admin user';
+  END IF;
+
+  RETURN QUERY
+  WITH primary_user_per_org AS (
+    SELECT DISTINCT ON (cp.organization_id) cp.*
+    FROM public.client_profiles cp
+    WHERE cp.organization_id IS NOT NULL
+    ORDER BY cp.organization_id, cp.created_at DESC
+  ),
+  orphan_users AS (
+    SELECT * FROM public.client_profiles WHERE organization_id IS NULL
+  ),
+  all_rows AS (
+    SELECT * FROM primary_user_per_org
+    UNION ALL
+    SELECT * FROM orphan_users
+  )
+  SELECT
+    o.id,
+    o.metadata->>'name',
+    o.company_url,
+    o.metadata->>'logo',
+    cp.user_id,
+    COALESCE(aa.full_legal_name, cp.user_name),
+    u.email::text,
+    CASE
+      WHEN aa.id IS NULL AND cp.organization_id IS NULL THEN 'signed_up'
+      WHEN aa.id IS NULL AND cp.is_onboarded = false    THEN 'onboarding'
+      WHEN aa.id IS NULL                                THEN 'onboarded_unsigned'
+      ELSE 'signed'
+    END,
+    aa.accepted_at,
+    aa.agreement_version,
+    aa.contracting_type,
+    aa.entity_name,
+    u.created_at
+  FROM all_rows cp
+  LEFT JOIN public.organizations o ON o.id = cp.organization_id
+  LEFT JOIN auth.users u           ON u.id = cp.user_id
+  LEFT JOIN LATERAL (
+    SELECT *
+    FROM public.agreement_acceptances
+    WHERE user_id = cp.user_id
+    ORDER BY accepted_at DESC
+    LIMIT 1
+  ) aa ON TRUE
+  ORDER BY u.created_at DESC;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.list_client_signatories_admin() TO authenticated;

--- a/supabase/migrations/20260427010245_fix_list_client_signatories_admin.sql
+++ b/supabase/migrations/20260427010245_fix_list_client_signatories_admin.sql
@@ -1,0 +1,79 @@
+-- Fix ambiguous column reference in list_client_signatories_admin.
+-- The orphan_users CTE used an unqualified `organization_id` reference, which PL/pgSQL
+-- confused with the RETURNS TABLE output variable of the same name (error 42702).
+-- Fix: use an explicit table alias in the orphan_users CTE.
+
+CREATE OR REPLACE FUNCTION public.list_client_signatories_admin()
+RETURNS TABLE (
+  organization_id uuid,
+  company_name text,
+  company_url text,
+  company_logo text,
+  signatory_user_id uuid,
+  signatory_name text,
+  signatory_email text,
+  status text,
+  signed_at timestamptz,
+  agreement_version text,
+  contracting_type text,
+  entity_name text,
+  signed_up_at timestamptz
+)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF (auth.jwt() -> 'app_metadata' ->> 'role') IS DISTINCT FROM 'admin' THEN
+    RAISE EXCEPTION 'Unauthorized: not an admin user';
+  END IF;
+
+  RETURN QUERY
+  WITH primary_user_per_org AS (
+    SELECT DISTINCT ON (cp.organization_id) cp.*
+    FROM public.client_profiles cp
+    WHERE cp.organization_id IS NOT NULL
+    ORDER BY cp.organization_id, cp.created_at DESC
+  ),
+  orphan_users AS (
+    -- Explicit alias avoids ambiguity with the RETURNS TABLE output variable `organization_id`
+    SELECT cp_o.* FROM public.client_profiles cp_o WHERE cp_o.organization_id IS NULL
+  ),
+  all_rows AS (
+    SELECT * FROM primary_user_per_org
+    UNION ALL
+    SELECT * FROM orphan_users
+  )
+  SELECT
+    o.id,
+    o.metadata->>'name',
+    o.company_url,
+    o.metadata->>'logo',
+    cp.user_id,
+    COALESCE(aa.full_legal_name, cp.user_name),
+    u.email::text,
+    CASE
+      WHEN aa.id IS NULL AND cp.organization_id IS NULL THEN 'signed_up'
+      WHEN aa.id IS NULL AND cp.is_onboarded = false    THEN 'onboarding'
+      WHEN aa.id IS NULL                                THEN 'onboarded_unsigned'
+      ELSE 'signed'
+    END,
+    aa.accepted_at,
+    aa.agreement_version,
+    aa.contracting_type,
+    aa.entity_name,
+    u.created_at
+  FROM all_rows cp
+  LEFT JOIN public.organizations o ON o.id = cp.organization_id
+  LEFT JOIN auth.users u           ON u.id = cp.user_id
+  LEFT JOIN LATERAL (
+    SELECT *
+    FROM public.agreement_acceptances
+    WHERE user_id = cp.user_id
+    ORDER BY accepted_at DESC
+    LIMIT 1
+  ) aa ON TRUE
+  ORDER BY u.created_at DESC;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.list_client_signatories_admin() TO authenticated;


### PR DESCRIPTION
## Summary
- Fixes Postgres error `42702` ("column reference 'organization_id' is ambiguous") in the `list_client_signatories_admin` RPC shipped in #118.
- The `orphan_users` CTE used an unqualified `organization_id`, which PL/pgSQL confused with the `RETURNS TABLE (organization_id uuid, …)` output variable of the same name.
- One-line fix: alias the table to `cp_o` and qualify the column (`cp_o.organization_id IS NULL`). Same signature, same logic — no behavioral change.

## Migration
`supabase/migrations/20260427010245_fix_list_client_signatories_admin.sql` — `CREATE OR REPLACE FUNCTION` with the qualified CTE.

## Test plan
- [x] Migration applied to production
- [x] RPC callable from ff-admin without throwing (verified by Ralph: `/clients` page now renders 9 client rows)
- [ ] Reviewer: confirm migration SQL is the only change

## Linked PR
Consumer of this RPC: Fractional-First/ff-admin (companion PR linked once created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)