### PR TITLE
ci: bump health-check workflow to Node 22

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -21,7 +21,7 @@ on:
         type: string
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "22"
 
 jobs:
   health-check:


### PR DESCRIPTION
## Summary
- The daily Service Health Check workflow has been failing because `@supabase/realtime-js` (transitively pulled by `@supabase/supabase-js`) requires native `WebSocket`, which Node 20 doesn't expose.
- The RPC-functions check was crashing inside `createClient()` before issuing any request — n8n + edge-function checks were unaffected.
- Node 22 (current LTS) has native `WebSocket`, so a one-line `NODE_VERSION` bump unblocks the run.

## Test plan
- [ ] Re-run the **Service Health Check** workflow manually from the Actions tab after merge and confirm all three stages (n8n, edge functions, RPC) complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)