### PR TITLE
fix: render functional skills regardless of profile_version label

### DIFF
--- a/src/components/edit-profile/FunctionalSkillsSection.tsx
+++ b/src/components/edit-profile/FunctionalSkillsSection.tsx
@@ -35,22 +35,22 @@ export const FunctionalSkillsSection: React.FC<
   content = "Organize your skills by category and provide details about your expertise level",
   readOnly = false,
 }) => {
-  // Determine if we're using the new structure (v0.2+)
-  const isNewStructure = profileVersion >= "0.2"
+  // Detect shape from the data itself, not the version label.
+  // Some rows have profile_version="0.1" but already store the new array shape
+  // (mislabelled by upstream pipelines), so a version-based gate misclassifies them.
+  const isNewStructure = Array.isArray(functionalSkills)
 
-  // Convert data to a consistent format for internal use
   const normalizeToOldStructure = (
     data: FunctionalSkillsData
   ): FunctionalSkills => {
-    if (isNewStructure && Array.isArray(data)) {
-      // Convert new structure to old structure
+    if (Array.isArray(data)) {
       const result: FunctionalSkills = {}
       data.forEach((group: FunctionalSkillGroup) => {
         result[group.name] = group.value
       })
       return result
     }
-    return data as FunctionalSkills
+    return (data || {}) as FunctionalSkills
   }
 
   const [localSkills, setLocalSkills] = useState<FunctionalSkills>(

--- a/supabase/migrations/20260507000000_relabel_v01_array_skills_to_v03.sql
+++ b/supabase/migrations/20260507000000_relabel_v01_array_skills_to_v03.sql
@@ -1,0 +1,33 @@
+-- Relabel mislabelled v0.1 profiles to v0.3.
+--
+-- Background:
+--   138 rows hold profile_version='0.1' but already store the v0.3-shape
+--   functional_skills (array of {name, value: [{title, description}, ...]}).
+--   The talentflow + public-profiles renderer gated shape detection on
+--   profileVersion >= "0.2", so these rows rendered with category headers
+--   "0", "1", "2" and empty skill lists.
+--
+--   The renderer has been updated to detect shape from the data itself, but
+--   the labels are still wrong and other code paths may branch on the
+--   profile_version string. This migration brings the labels in line with
+--   the actual data shape (v0.1 and v0.3 have identical top-level keys, so
+--   "0.3" is the correct label for these rows).
+--
+-- Affected: 138 rows (35 authenticated 2025-07-21..2025-08-31, 103 guest
+-- 2026-03-02..2026-03-03). All have functional_skills in array shape.
+
+UPDATE public.profiles
+SET
+  profile_version = '0.3',
+  anon_profile_data = CASE
+    WHEN anon_profile_data ? 'profile_version'
+      THEN jsonb_set(anon_profile_data, '{profile_version}', '"0.3"')
+    ELSE anon_profile_data
+  END,
+  profile_data = CASE
+    WHEN profile_data IS NOT NULL AND profile_data ? 'profile_version'
+      THEN jsonb_set(profile_data, '{profile_version}', '"0.3"')
+    ELSE profile_data
+  END
+WHERE profile_version = '0.1'
+  AND jsonb_typeof(anon_profile_data->'functional_skills') = 'array';


### PR DESCRIPTION
## Summary

- **Renderer:** detect functional_skills shape via `Array.isArray()` instead of `profileVersion >= "0.2"`. 138 rows hold `profile_version="0.1"` but already store the new array-of-`{name, value}` shape; the version-gated check fell through to `Object.entries(array)` and rendered category headers `0`, `1`, `2` with empty skill lists (e.g. Brian Wong's profile).
- **Data:** migration `20260507000000_relabel_v01_array_skills_to_v03.sql` sets `profile_version = '0.3'` on the column + embedded JSONB for those 138 rows. Top-level keys are identical between v0.1 and v0.3, so `'0.3'` is the correct label.

The renderer fix alone is enough to fix the UI; the data migration is cleanup so other code paths that branch on the version string see the truth.

Companion PR (same renderer change in public-profiles): Fractional-First/candidates#5

## Test plan

- [ ] Build and lint pass
- [ ] Brian Wong's profile (or any v0.1-labelled profile) renders Functional Skills correctly with real category names and bullets
- [ ] No regression on v0.2 / v0.3 profiles
- [ ] Migration applied; spot-check that profiles with profile_version='0.1' returns 0 rows

## Out of scope (follow-ups)

- Pipeline that hardcodes \`"profile_version": "0.1"\` into JSONB payloads (likely n8n \`generate-profile-guest\`).
- \`profiles.profile_version\` column default of \`'0.1'\` (baseline.sql:1460) — should be \`'0.3'\` so future direct inserts can't regress.