### PR TITLE
docs: fix README migration workflow filename and add SUPABASE_PROJECT_REF

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ We don't support custom domains (yet). If you want to deploy your project under 
 
 ## How DB migrations ship
 
-Schema changes live in `supabase/migrations/`. When a PR that touches that folder merges into `main`, the **Supabase DB Push** GitHub Action (`.github/workflows/supabase-db-push.yml`) runs `supabase db push --linked` against the production project ref pinned in `supabase/config.toml`. The job prints `migration list` and a `--dry-run` plan before applying, fails loudly on history conflicts, and is a no-op when no new migrations are present. You can also trigger it manually from the Actions tab with `dry_run = true` to inspect the plan without writing.
+Schema changes live in `supabase/migrations/`. When a PR that touches that folder merges into `main`, the **Apply Supabase Migrations** GitHub Action (`.github/workflows/migrate.yml`) runs `supabase db push --linked` against the production project ref. The job prints `migration list` and a `--dry-run` plan before applying, fails loudly on history conflicts, and is a no-op when no new migrations are present. You can also trigger it manually from the Actions tab with `dry_run = true` to inspect the plan without writing.
 
-Two repo secrets must be present for the workflow to succeed: `SUPABASE_ACCESS_TOKEN` (Supabase personal access token) and `SUPABASE_DB_PASSWORD` (the linked project's DB password). See `docs/ci/README.md` if the workflow file is still staged there pending activation.
+Three repo secrets must be present for the workflow to succeed: `SUPABASE_ACCESS_TOKEN` (Supabase personal access token), `SUPABASE_DB_PASSWORD` (the linked project's DB password), and `SUPABASE_PROJECT_REF` (the Supabase project reference ID). The workflow fails loudly if any of these are missing.
 
 # Fractional First – UX & Design System (Mobile-First)
 


### PR DESCRIPTION
## Summary

- Corrects the workflow filename in the "How DB migrations ship" README blurb from `supabase-db-push.yml` → `migrate.yml` (the file that actually exists and is live)
- Adds the missing `SUPABASE_PROJECT_REF` secret to the documented requirements (the workflow already validates all three, the README only listed two)
- Removes stale reference to `docs/ci/README.md` (that path doesn't exist)

The `migrate.yml` workflow itself (merged in #125) already fully implements the Supabase DB push gate from FRA-5. This PR just corrects the documentation to match.

## Secrets required in repo settings

Before the workflow will fire successfully, three secrets must be set at `Settings → Secrets → Actions`:

| Secret | What it is |
|---|---|
| `SUPABASE_ACCESS_TOKEN` | Supabase personal access token |
| `SUPABASE_DB_PASSWORD` | Password for the linked project's Postgres DB |
| `SUPABASE_PROJECT_REF` | Project reference ID from the Supabase dashboard |

🤖 Generated with [Claude Code](https://claude.com/claude-code)