### PR TITLE
fix(rpc): restore get_anon_profile visibility for unpublished profiles

### DIFF
--- a/supabase/migrations/20260529100000_fix_get_anon_profile_security_definer.sql
+++ b/supabase/migrations/20260529100000_fix_get_anon_profile_security_definer.sql
@@ -1,0 +1,51 @@
+-- Fix get_anon_profile to run with SECURITY DEFINER so the anon key can read
+-- profile_data.profilePicture (Supabase Storage URL for authenticated users).
+--
+-- Background: migration 20260529000000 accidentally omitted SECURITY DEFINER,
+-- reverting to the default SECURITY INVOKER. RLS prevents the anon role from
+-- reading profile_data, so authenticated users' photos were never merged into
+-- the returned anon_profile_data, causing the /api/avatar/[slug] route to
+-- return 404 for all authenticated profiles.
+--
+-- The ispublished = true guard is belt-and-suspenders: only published profiles
+-- are ever returned regardless of RLS bypass.
+CREATE OR REPLACE FUNCTION get_anon_profile(anon_slug_param TEXT)
+RETURNS TABLE(anon_slug TEXT, anon_profile_data JSONB, profile_version TEXT, profile_type TEXT)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  profile_record RECORD;
+  photo_url TEXT;
+  merged_data JSONB;
+BEGIN
+  SELECT p.anon_slug, p.anon_profile_data, p.profile_version, p.profile_type::text, p.profile_data
+  INTO profile_record
+  FROM public.profiles AS p
+  WHERE p.anon_slug = anon_slug_param
+    AND p.ispublished = true
+  LIMIT 1;
+
+  IF NOT FOUND THEN RETURN; END IF;
+  IF profile_record.anon_profile_data IS NULL THEN RETURN; END IF;
+
+  -- Prefer authenticated user's Supabase Storage URL; fall back to whatever
+  -- is already in anon_profile_data (LinkedIn CDN for guest profiles).
+  photo_url := COALESCE(
+    NULLIF(profile_record.profile_data->>'profilePicture', ''),
+    profile_record.anon_profile_data->>'profilePicture'
+  );
+
+  merged_data := CASE
+    WHEN photo_url IS NOT NULL
+    THEN profile_record.anon_profile_data || jsonb_build_object('profilePicture', photo_url)
+    ELSE profile_record.anon_profile_data
+  END;
+
+  RETURN QUERY SELECT
+    profile_record.anon_slug,
+    merged_data,
+    profile_record.profile_version,
+    profile_record.profile_type;
+END;
+$$;

--- a/supabase/migrations/20260529120000_fix_get_anon_profile_remove_ispublished_filter.sql
+++ b/supabase/migrations/20260529120000_fix_get_anon_profile_remove_ispublished_filter.sql
@@ -1,0 +1,47 @@
+-- Fix regression introduced in 20260529000000: that migration added
+-- AND p.ispublished = true which broke profiles with ispublished = false
+-- that were previously publicly accessible.
+-- The original function had no ispublished filter — any profile with a
+-- matching anon_slug and non-null anon_profile_data was returned.
+-- Restore that behaviour while keeping the SECURITY DEFINER, profile_type
+-- return column, and photo URL merge logic from the previous migration.
+CREATE OR REPLACE FUNCTION get_anon_profile(anon_slug_param TEXT)
+RETURNS TABLE(anon_slug TEXT, anon_profile_data JSONB, profile_version TEXT, profile_type TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  profile_record RECORD;
+  photo_url TEXT;
+  merged_data JSONB;
+BEGIN
+  SELECT p.anon_slug, p.anon_profile_data, p.profile_version, p.profile_type::text, p.profile_data
+  INTO profile_record
+  FROM public.profiles AS p
+  WHERE p.anon_slug = anon_slug_param
+  LIMIT 1;
+
+  IF NOT FOUND THEN RETURN; END IF;
+  IF profile_record.anon_profile_data IS NULL THEN RETURN; END IF;
+
+  -- Prefer authenticated user's Supabase Storage URL; fall back to whatever
+  -- is already in anon_profile_data (LinkedIn CDN for guest profiles).
+  photo_url := COALESCE(
+    NULLIF(profile_record.profile_data->>'profilePicture', ''),
+    profile_record.anon_profile_data->>'profilePicture'
+  );
+
+  merged_data := CASE
+    WHEN photo_url IS NOT NULL
+    THEN profile_record.anon_profile_data || jsonb_build_object('profilePicture', photo_url)
+    ELSE profile_record.anon_profile_data
+  END;
+
+  RETURN QUERY SELECT
+    profile_record.anon_slug,
+    merged_data,
+    profile_record.profile_version,
+    profile_record.profile_type;
+END;
+$$;


### PR DESCRIPTION
## Problem

Regression from PR #133 (`20260529000000` migration): adding `AND p.ispublished = true` broke public access to anonymous profiles where `ispublished = false`.

Example: `experienced-ux-designer-researcher-2` (onboarding_status: `PROFILE_GENERATED`, ispublished: false) now 404s on `candidates.fractionalfirst.com`.

## Root cause

The original `get_anon_profile` had no `ispublished` filter. The gate was simply: does the profile have an `anon_slug` + non-null `anon_profile_data`? The `ispublished = true` check was added as "belt-and-suspenders" but unintentionally hid profiles that should remain visible.

## Fix

Remove `AND p.ispublished = true`. All other improvements from PR #133 are preserved: `SECURITY DEFINER`, `profile_type` return column, photo URL merge logic.

## Deploy

Merge triggers `migrate.yml` which applies the migration to production Supabase automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)