### PR TITLE
fix(cors): correct origins in submit-shortlist shared cors

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,25 +1,29 @@
 const ALLOWED_ORIGINS = [
-  "https://app.fractionalfirst.com",
-  "https://candidates.fractionalfirst.com",
-  "https://orgs.fractionalfirst.com",
+  "https://role-description-generator.fractionalfirst.com",
+  "https://rdg.fractionalfirst.com",
   "https://guest-jd-generator.netlify.app",
+  "http://localhost:5173",
+];
+
+const ALLOWED_PATTERNS = [
+  /^https:\/\/deploy-preview-\d+--guest-jd-generator\.netlify\.app$/,
 ];
 
 export function corsHeaders(origin: string | null): Record<string, string> {
-  const allowedOrigin =
-    origin && ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0];
-  return {
-    "Access-Control-Allow-Origin": allowedOrigin,
-    "Access-Control-Allow-Headers":
-      "authorization, x-client-info, apikey, content-type",
+  const headers: Record<string, string> = {
     "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "content-type, authorization, apikey, x-client-info",
+    "Vary": "Origin",
   };
+  if (origin && (ALLOWED_ORIGINS.includes(origin) || ALLOWED_PATTERNS.some(p => p.test(origin)))) {
+    headers["Access-Control-Allow-Origin"] = origin;
+  }
+  return headers;
 }
 
 export function handlePreflight(req: Request): Response | null {
   if (req.method === "OPTIONS") {
-    const origin = req.headers.get("origin");
-    return new Response(null, { status: 204, headers: corsHeaders(origin) });
+    return new Response(null, { status: 204, headers: corsHeaders(req.headers.get("origin")) });
   }
   return null;
 }

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,4 +1,7 @@
 const ALLOWED_ORIGINS = [
+  "https://app.fractionalfirst.com",
+  "https://candidates.fractionalfirst.com",
+  "https://orgs.fractionalfirst.com",
   "https://role-description-generator.fractionalfirst.com",
   "https://rdg.fractionalfirst.com",
   "https://guest-jd-generator.netlify.app",


### PR DESCRIPTION
## Problem

`_shared/cors.ts` deployed with `submit-shortlist` had wrong origins and returned `app.fractionalfirst.com` as a hardcoded fallback — blocking requests from `role-description-generator.fractionalfirst.com`.

## Fix

Correct allowlist matching `submit-rdg-lead`: `role-description-generator.fractionalfirst.com`, `rdg.fractionalfirst.com`, `guest-jd-generator.netlify.app`, `localhost:5173`, deploy preview pattern. No hardcoded fallback.

## After merging

```bash
npx supabase functions deploy submit-shortlist --project-ref dtyugokvlksnatftpucm
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)