### PR TITLE
fix(cors): correct client-portal origin to clients.fractionalfirst.com

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,11 +1,12 @@
 const ALLOWED_ORIGINS = [
   "https://app.fractionalfirst.com",
   "https://candidates.fractionalfirst.com",
-  "https://orgs.fractionalfirst.com",
+  "https://clients.fractionalfirst.com",
   "https://role-description-generator.fractionalfirst.com",
   "https://rdg.fractionalfirst.com",
   "https://guest-jd-generator.netlify.app",
   "http://localhost:5173",
+  "http://localhost:3000",
 ];
 
 const ALLOWED_PATTERNS = [


### PR DESCRIPTION
## What

The shared CORS allowlist (`supabase/functions/_shared/cors.ts`), used by the **`submit-rdg-lead`** and **`submit-shortlist`** edge functions, listed `https://orgs.fractionalfirst.com` as the client-portal origin. That domain **has no DNS record and never went live**.

The client portal is actually served from **`https://clients.fractionalfirst.com`** (DNS → `ff-client-portal.netlify.app`, returns 200 → `/login`).

Until this is fixed, once the RDG flow ships in the portal, the browser's CORS preflight from `clients.fractionalfirst.com` would be **rejected** by both edge functions — shortlist + custom-search submissions would silently fail.

## Changes

- Replace dead `https://orgs.fractionalfirst.com` → `https://clients.fractionalfirst.com`
- Add `http://localhost:3000` so the portal (Next.js `next dev`) can exercise the flow locally (the existing `:5173` was the old Vite/guest-jd-generator port)

Single file, two lines. No logic change.

## Verify after deploy

```bash
curl -X OPTIONS https://dtyugokvlksnatftpucm.supabase.co/functions/v1/submit-rdg-lead \
  -H "origin: https://clients.fractionalfirst.com" -i
```
Expect `204` with `Access-Control-Allow-Origin: https://clients.fractionalfirst.com`.

## Deploy (manual)

```bash
cd talentflow
gh auth switch --user adam-frationalfirst
npx supabase functions deploy submit-rdg-lead
npx supabase functions deploy submit-shortlist
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)