### PR TITLE
feat(rdg): jd_created notification email for client portal

### DIFF
--- a/supabase/functions/submit-rdg-lead/index.ts
+++ b/supabase/functions/submit-rdg-lead/index.ts
@@ -19,6 +19,34 @@ Deno.serve(async (req) => {
   let body: any;
   try { body = await req.json(); } catch { return new Response(JSON.stringify({ error: "Invalid JSON" }), { status: 400, headers: { ...cors, "content-type": "application/json" } }); }
 
+  // Internal FYI — a client generated a role description (clicked "Continue to
+  // Download" in the client portal). Notifies the FF team only; the client sees
+  // nothing. jdSlug may be null if the create_job_description RPC hadn't resolved
+  // by the time the portal fired this off.
+  if (body.type === "jd_created") {
+    if (!body.email) {
+      return new Response(JSON.stringify({ error: "Missing required fields: email" }), {
+        status: 400, headers: { ...cors, "content-type": "application/json" }
+      });
+    }
+    const name = `${body.firstName ?? ""}${body.lastName ? " " + body.lastName : ""}`.trim() || "A client";
+    const jdUrl = body.jdSlug ? `https://roles.fractionalfirst.com/${body.jdSlug}` : null;
+    const subject = `[RDG] Role generated — ${body.companyName ?? "Unknown"}${body.jdRoleTitle ? ` (${body.jdRoleTitle})` : ""}`;
+    const html = `<h2>Role Description Generated</h2>
+       <p><strong>${name}</strong> &lt;${body.email}&gt;${body.designation ? ` — ${body.designation}` : ""}</p>
+       <p><strong>Company:</strong> ${body.companyName ?? "Unknown"}</p>
+       <p><strong>Role:</strong> ${body.jdRoleTitle ?? "Unknown"}</p>
+       ${jdUrl ? `<p><a href="${jdUrl}">View JD on roles site</a></p>` : "<p><em>JD slug not yet available.</em></p>"}
+       <p style="color:#888;font-size:12px;">Triggered when the client clicked &ldquo;Continue to Download&rdquo; in the client portal.</p>`;
+    const r = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { authorization: `Bearer ${RESEND_API_KEY}`, "content-type": "application/json" },
+      body: JSON.stringify({ from: FROM, to: NOTIFY_TO, reply_to: body.email, subject, html }),
+    });
+    if (!r.ok) console.error("[submit-rdg-lead] Resend error (jd_created)", r.status, await r.text());
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { ...cors, "content-type": "application/json" } });
+  }
+
   // New branch — shortlist and custom-search from authenticated portal
   if (body.type === "shortlist" || body.type === "custom_search") {
     if (!body.firstName || !body.email) {


### PR DESCRIPTION
## What

Adds a `jd_created` handler branch to the `submit-rdg-lead` edge function. When a client clicks **Continue to Download** in the client portal (RDG flow), the portal fires a fire-and-forget `jd_created` event. This branch emails the FF team (reza/adam/daniel) an internal FYI containing:

- Client name, email (set as `reply_to`), designation
- Company name
- Role title
- A link to the generated JD on `roles.fractionalfirst.com/{slug}`

The client sees nothing — no UI feedback, no notification.

## Notes

- Branch is placed **before** the existing `shortlist`/`custom_search` branch.
- Requires only `body.email`. `jdSlug` may be `null` if the `create_job_description` RPC hadn't resolved by the time the portal fired the event — the email handles this gracefully.
- **Deployment:** this edge function must be redeployed for the email to fire in prod.

## Related

Pairs with the client-portal side: Fractional-First/ff-client-portal#14 (which fires the `jd_created` event and now publishes the JD so the linked roles-site URL resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)