### PR TITLE
fix(rdg): make submit-rdg-lead public (verify_jwt=false) — fixes guest RDG 401

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -8,3 +8,15 @@ verify_jwt = false
 
 [functions.record-agreement-acceptance]
 verify_jwt = true
+
+# Public lead-capture endpoints — called anonymously from the RDG / guest JD
+# generator browser bundle. They self-protect via the CORS origin allowlist
+# (_shared/cors.ts) and required-field validation, and write internally with the
+# service role. They must NOT require a JWT, or the gateway 401s before the
+# function runs (UNAUTHORIZED_NO_AUTH_HEADER). Keep these here so redeploys don't
+# default back to verify_jwt = true.
+[functions.submit-rdg-lead]
+verify_jwt = false
+
+[functions.submit-shortlist]
+verify_jwt = false


### PR DESCRIPTION
## Problem
The public/guest RDG submit button returned a **401** (`UNAUTHORIZED_NO_AUTH_HEADER` / "missing authorization header"), reported by Daniel.

## Root cause
`submit-rdg-lead` is called directly from the browser (guest JD generator / public RDG) with **no Authorization header**, but was deployed with `verify_jwt = true` — so Supabase's gateway rejects the request *before the function runs*. `config.toml` had **no entry** for the function, so every redeploy defaulted it back to `verify_jwt = true` (this is what reintroduced the bug after the recent task-10 redeploy).

The client portal already worked around this by proxying server-side and forwarding the anon key; the guest generator never did.

## Fix
Pin `verify_jwt = false` for `submit-rdg-lead` and `submit-shortlist` in `config.toml`. These are public, anonymous lead-capture endpoints that self-protect via the CORS origin allowlist (`_shared/cors.ts`) + required-field validation, and write internally with the service role — same posture as `google-places` / `google-place-details`.

## Deploy status
- ✅ `submit-rdg-lead` already redeployed with `--no-verify-jwt` (now **v11, `verify_jwt: false`**). Verified: the auth-less call now returns `400` (function validation) instead of `401` (gateway).
- ⏳ `submit-shortlist` still live with `verify_jwt: true` — it isn't wired to the guest browser, so it'll pick up the config on its next deploy.

No frontend change or rebuild was required — the fix is the server-side flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRMnCvLUfnTzMiNBetvpBe