### PR TITLE
Add candidate_annotations table for admin candidate notes (ff-workspace#4)

### DIFF
--- a/supabase/migrations/20260812090000_candidate_annotations.sql
+++ b/supabase/migrations/20260812090000_candidate_annotations.sql
@@ -1,0 +1,33 @@
+-- Admin-authored candidate annotations (notes, comments, transcripts, rate details, links)
+-- shown in the ff-admin candidate drawer (ff-workspace#4)
+-- Append-only design; consumed by ff-admin via direct .from() under logged-in admin session
+-- RLS policies gate access using admin JWT claim
+
+CREATE TABLE public.candidate_annotations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  kind text NOT NULL CHECK (kind IN ('note', 'comment', 'transcript', 'rate', 'link')),
+  body text NOT NULL,
+  url text,
+  created_by uuid NOT NULL DEFAULT auth.uid(),
+  created_by_email text DEFAULT (auth.jwt() ->> 'email'),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX candidate_annotations_profile_id_created_at_idx ON public.candidate_annotations (profile_id, created_at DESC);
+
+ALTER TABLE public.candidate_annotations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "candidate_annotations_admin_select" ON public.candidate_annotations
+  FOR SELECT TO authenticated
+  USING ((auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');
+
+-- WITH CHECK also pins authorship to the caller: the column defaults satisfy it,
+-- but a client supplying someone else's created_by/created_by_email is rejected.
+CREATE POLICY "candidate_annotations_admin_insert" ON public.candidate_annotations
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (auth.jwt() -> 'app_metadata' ->> 'role') = 'admin'
+    AND created_by = auth.uid()
+    AND created_by_email IS NOT DISTINCT FROM (auth.jwt() ->> 'email')
+  );


### PR DESCRIPTION
## Summary

New append-only `candidate_annotations` table backing the ff-admin candidate drawer's **Notes & Files** section (ff-workspace#4): notes, comments, transcripts, rate details, and file/drive links logged by admins against a candidate.

Design (per Daniel's spec — deliberately lightweight):
- One table; each row is a `kind` (`note`/`comment`/`transcript`/`rate`/`link`) + free-form `body`, with `url` populated only for links. Rates are plain text, not structured.
- `profile_id uuid → profiles(id) ON DELETE CASCADE` (mirrors `agreement_acceptances`).
- **RLS is load-bearing**: ff-admin runs on the anon key + a real admin session (no service role), and talentflow candidates authenticate against this same project — so SELECT/INSERT are restricted to the admin JWT claim `(auth.jwt() -> 'app_metadata' ->> 'role') = 'admin'`, mirroring the `rdg_leads` policy pattern. No UPDATE/DELETE policies (append-only by design).
- Authorship stamped server-side (`created_by DEFAULT auth.uid()`, `created_by_email DEFAULT auth.jwt()->>'email'`) so clients can't spoof it.

Issue: Fractional-First/ff-workspace#4 (close is owned by the ff-admin PR)

## Linked PRs

- Consumer: Fractional-First/ff-admin#14 — **merge order: this PR first**, then human `supabase db push`, then the ff-admin PR (its preview needs this table to exist).

## Acceptance criteria (this PR's share)

- [x] "Entries persist to a real Supabase table" — table + admin-only RLS created here; wiring/demo-removal lands in the ff-admin PR.
- All UI criteria are owned by the ff-admin PR.

## Test gate

- `npx tsc -b --noEmit` ✅ · `npm run test:run` ✅ 10/10 · `npm run build` ✅ (SQL-only diff; gates run as guard)

## Local review

**Round 1:** no verdict (reviewer sidetracked by untracked `.tsbuildinfo` gate artifacts; excluded from the commit). Re-run with an artifact-ignore note.
**Round 2:** FINDINGS — 1 LOW: the INSERT policy accepted client-supplied `created_by`/`created_by_email` (column defaults only apply when omitted, so an admin client could attribute an entry to someone else). **Fixed in this PR** — `WITH CHECK` now pins `created_by = auth.uid()` and `created_by_email` to the JWT email; the ff-admin client omits both, so the defaults satisfy the check.
**Final:** all findings resolved; full gate re-run green after the fix.

## Visual evidence

No visual surface — migration-only diff; verified by the talentflow gate above and by the ff-admin PR's preview steps once this is applied.

## How to apply & verify (~2 min)

1. Merge this PR — the **Apply Supabase Migrations** workflow (`migrate.yml`) triggers on merge (push to `main` touching `supabase/migrations/**`) and applies it to production automatically. Watch the Actions run go green; no manual push needed (the dry-run default only applies to manual dispatch).
2. Verify: Supabase Dashboard → Database → Tables → `candidate_annotations` shows RLS **enabled** with 2 policies (`candidate_annotations_admin_select`, `candidate_annotations_admin_insert`).
3. Then the ff-admin#14 preview is testable end-to-end — its steps prove admin read/write works and candidates are locked out.
